### PR TITLE
JBIDE-13093 - Error in gwt quickstart due to space in workspace path

### DIFF
--- a/jbosstools/examples/project-examples-shared-4.0.Beta2.xml
+++ b/jbosstools/examples/project-examples-shared-4.0.Beta2.xml
@@ -346,7 +346,7 @@ Make sure you read the deployment instructions in README.md.</description>
         <mavenArchetype>
 			<archetypeGroupId>org.jboss.errai.archetypes</archetypeGroupId>
 			<archetypeArtifactId>jboss-errai-kitchensink-archetype</archetypeArtifactId>
-			<archetypeVersion>2.0.0.Final</archetypeVersion>
+			<archetypeVersion>2.1.1.Final</archetypeVersion>
             <!--
 
 			<archetypeRepository>https://repository.jboss.org/nexus/content/groups/public/</archetypeRepository>

--- a/jbosstools/examples/project-examples-shared-4.0.CR1.xml
+++ b/jbosstools/examples/project-examples-shared-4.0.CR1.xml
@@ -353,7 +353,7 @@ IMPORTANT : Make sure you read the deployment instructions in README.md.</descri
         <mavenArchetype>
 			<archetypeGroupId>org.jboss.errai.archetypes</archetypeGroupId>
 			<archetypeArtifactId>jboss-errai-kitchensink-archetype</archetypeArtifactId>
-			<archetypeVersion>2.0.0.Final</archetypeVersion>
+			<archetypeVersion>2.1.1.Final</archetypeVersion>
             <!--
 			<archetypeRepository>https://repository.jboss.org/nexus/content/groups/public/</archetypeRepository>
             -->


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-13093 - Error in gwt quickstart due to space in workspace path
