### PR TITLE
JBTIS-217 - update bpmn2 modeler to 1.0.1

### DIFF
--- a/jbosstools/updates/requirements/bpmn2-modeler/build.xml
+++ b/jbosstools/updates/requirements/bpmn2-modeler/build.xml
@@ -7,15 +7,16 @@
   -->
 
   <!-- as of 0.2.7 this works with Juno and Kepler. Depends on Graphiti 0.10.x -->
-  <property name="LONGNAME" value="Eclipse BPMN 2 Modeler + BPMN2 Project Feature"/>
-  <property name="version" value="1.0"/>
-  <property name="version2" value="1.0.0.201311042148"/>
+  <property name="LONGNAME" value="Eclipse BPMN2 Modeler + BPMN2 Project Feature"/>
+  <property name="version" value="1.0.1"/>
+  <property name="version2" value="1.0.1.201311222008"/>
   <property name="version3" value="S20130822"/>
   <property name="version4" value="0.7.0.201308220617"/>
 
-  <!--   BPMN2 Editor 1.0.0.201311042148 -->
+  <!--   BPMN2 Editor 1.0.1.201311222008 -->
   <!-- <property name="URL" value="http://download.eclipse.org/bpmn2-modeler/site/" /> -->
   <property name="URL" value="http://download.eclipse.org/bpmn2-modeler/updates/kepler/${version}/" />
+
   <!-- BPMN2 Project Feature 0.7.0.201308220617 -->
   <property name="URL2" value="http://download.eclipse.org/modeling/mdt/bpmn2/updates/milestones/${version3}/" />
   <property name="latestversiononly" value="false"/>


### PR DESCRIPTION
Please merge/push the following update to bpmn2 modeler - 1.0.1.201311222008

ref: http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/1.0.1.201311222008_0.7.0.201308220617_kepler/
