### PR TITLE
JBTIS-333 - bpmn2 modeler 1.1.1 - Luna

### DIFF
--- a/jbosstools/updates/requirements/bpmn2-modeler/build.xml
+++ b/jbosstools/updates/requirements/bpmn2-modeler/build.xml
@@ -8,12 +8,12 @@
 
   <property name="LONGNAME" value="Eclipse BPMN2 Modeler + BPMN2 Project Feature"/>
   <property name="version" value="1.1.1"/>
-  <property name="version2" value="1.1.1.201409261846"/>
+  <property name="version2" value="1.1.1.201410152001"/>
   <property name="version3" value="S20130822"/>
   <property name="version4" value="0.7.0.201308220617"/>
   <property name="eclver" value="luna"/>
 
-  <!--   BPMN2 Editor 1.1.1.201409261846 -->
+  <!--   BPMN2 Editor 1.1.1.201410152001 -->
   <!-- <property name="URL" value="http://download.eclipse.org/bpmn2-modeler/site/" /> -->
   <property name="URL" value="http://download.eclipse.org/bpmn2-modeler/updates/${eclver}/${version}/" />
 


### PR DESCRIPTION
Update for source bundle feature.  Also pick up these bug fixes:
 Bug 446154 - Unable to set onEntry/onExit script for embedded AdHocSubprocess
Bug 417015 - Missing 'drools' expression language for conditions.
RH Bug 1150074 - Add logic to properly display Start Events "Is Interrupting" and Boundary Events "Cancel Activity" attributes.
RH Bug 1150060 - Don't use targetNamespace prefixes for BPMN2 object ID references
RH Bug 1146372 - Make "id" features read-only
RH Bug 1149515 - Bpmn2 Diagram Editor which comes with JBDS Integration Stack does not provide facility of writing On Entry / On Exit scripts for custom service tasks
RH Bug 1146739 - save progress is stopped
JBTIS Bug 332 - update poms to generate source bundles 
