### PR TITLE
JBDS-4322 URLs for Devstudio 10.4. and JBT 4.4. fixed.

### DIFF
--- a/jbosstools/configuration/ide-config.properties
+++ b/jbosstools/configuration/ide-config.properties
@@ -1,18 +1,18 @@
 ### CI snapshot builds
-# master version of jbosstools-earlyaccess.properties should be edited here, so the discovery job can fetch it: http://download.jboss.org/jbosstools/neon/snapshots/updates/earlyaccess.properties/master/jbosstools-earlyaccess.properties
-jboss.discovery.directory.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/jbosstools-directory.xml
-jboss.discovery.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.central_master/latest/all/repo/
-jboss.discovery.earlyaccess.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/
-jboss.discovery.earlyaccess.list.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/jbosstools-earlyaccess.properties
+# 4.4.neon version of jbosstools-earlyaccess.properties should be edited here, so the discovery job can fetch it: http://download.jboss.org/jbosstools/neon/snapshots/updates/earlyaccess.properties/4.4.neon/jbosstools-earlyaccess.properties
+jboss.discovery.directory.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/jbosstools-directory.xml
+jboss.discovery.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.central_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.list.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/jbosstools-earlyaccess.properties
 jboss.central.webpage.url|jbosstools|4.4.4.AM2=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=public-jboss&g=org.jboss.tools.central&a=jbosstools-central-webpage&v=2.0.0-SNAPSHOT&e=zip&mustEndWith=.zip
 jboss.discovery.site.integration-stack.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/discovery/
 jboss.discovery.earlyaccess.site.integration-stack.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/discovery/earlyaccess/
 jboss.discovery.site.integration-stack-sap.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/extras/
-# master version of devstudio-earlyaccess.properties should be edited here, so the discovery job can fetch it: https://devstudio.redhat.com/10.0/snapshots/updates/earlyaccess.properties/master/devstudio-earlyaccess.properties
-jboss.discovery.directory.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/devstudio-directory.xml
-jboss.discovery.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.central_master/latest/all/repo/
-jboss.discovery.earlyaccess.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/
-jboss.discovery.earlyaccess.list.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/devstudio-earlyaccess.properties
+# 4.4.neon version of devstudio-earlyaccess.properties should be edited here, so the discovery job can fetch it: https://devstudio.redhat.com/10.0/snapshots/updates/earlyaccess.properties/4.4.neon/devstudio-earlyaccess.properties
+jboss.discovery.directory.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/devstudio-directory.xml
+jboss.discovery.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.central_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.list.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/devstudio-earlyaccess.properties
 jboss.central.webpage.url|devstudio|10.4.0.AM2=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=public-jboss&g=org.jboss.tools.central&a=jbosstools-central-webpage&v=2.0.0-SNAPSHOT&e=zip&mustEndWith=.zip
 jboss.discovery.site.integration-stack.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/development/updates/integration-stack/discovery/
 jboss.discovery.earlyaccess.site.integration-stack.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/development/updates/integration-stack/discovery/earlyaccess/

--- a/jbosstools/configuration/src/main/ide-config.current-snapshots-fragment.properties
+++ b/jbosstools/configuration/src/main/ide-config.current-snapshots-fragment.properties
@@ -1,18 +1,18 @@
 ### CI snapshot builds
-# master version of jbosstools-earlyaccess.properties should be edited here, so the discovery job can fetch it: http://download.jboss.org/jbosstools/neon/snapshots/updates/earlyaccess.properties/master/jbosstools-earlyaccess.properties
-jboss.discovery.directory.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/jbosstools-directory.xml
-jboss.discovery.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.central_master/latest/all/repo/
-jboss.discovery.earlyaccess.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/
-jboss.discovery.earlyaccess.list.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/jbosstools-earlyaccess.properties
+# 4.4.neon version of jbosstools-earlyaccess.properties should be edited here, so the discovery job can fetch it: http://download.jboss.org/jbosstools/neon/snapshots/updates/earlyaccess.properties/4.4.neon/jbosstools-earlyaccess.properties
+jboss.discovery.directory.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/jbosstools-directory.xml
+jboss.discovery.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.central_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.site.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.list.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/jbosstools-earlyaccess.properties
 jboss.central.webpage.url|jbosstools|4.4.4.AM2=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=public-jboss&g=org.jboss.tools.central&a=jbosstools-central-webpage&v=2.0.0-SNAPSHOT&e=zip&mustEndWith=.zip
 jboss.discovery.site.integration-stack.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/discovery/
 jboss.discovery.earlyaccess.site.integration-stack.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/discovery/earlyaccess/
 jboss.discovery.site.integration-stack-sap.url|jbosstools|4.4.4.AM2=http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/extras/
-# master version of devstudio-earlyaccess.properties should be edited here, so the discovery job can fetch it: https://devstudio.redhat.com/10.0/snapshots/updates/earlyaccess.properties/master/devstudio-earlyaccess.properties
-jboss.discovery.directory.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/devstudio-directory.xml
-jboss.discovery.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.central_master/latest/all/repo/
-jboss.discovery.earlyaccess.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/
-jboss.discovery.earlyaccess.list.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_master/latest/all/repo/devstudio-earlyaccess.properties
+# 4.4.neon version of devstudio-earlyaccess.properties should be edited here, so the discovery job can fetch it: https://devstudio.redhat.com/10.0/snapshots/updates/earlyaccess.properties/4.4.neon/devstudio-earlyaccess.properties
+jboss.discovery.directory.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/devstudio-directory.xml
+jboss.discovery.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.central_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.site.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/
+jboss.discovery.earlyaccess.list.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/snapshots/builds/jbosstools-discovery.earlyaccess_4.4.neon/latest/all/repo/devstudio-earlyaccess.properties
 jboss.central.webpage.url|devstudio|10.4.0.AM2=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=public-jboss&g=org.jboss.tools.central&a=jbosstools-central-webpage&v=2.0.0-SNAPSHOT&e=zip&mustEndWith=.zip
 jboss.discovery.site.integration-stack.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/development/updates/integration-stack/discovery/
 jboss.discovery.earlyaccess.site.integration-stack.url|devstudio|10.4.0.AM2=https://devstudio.redhat.com/10.0/development/updates/integration-stack/discovery/earlyaccess/


### PR DESCRIPTION
Links in snapshot section will point to 4.4.neon folders.