### PR TITLE
use...

### DIFF
--- a/jbosstools/oxygen/snapshots/builds/_composite_/core/4.5.oxygen/compositeArtifacts.xml
+++ b/jbosstools/oxygen/snapshots/builds/_composite_/core/4.5.oxygen/compositeArtifacts.xml
@@ -8,7 +8,7 @@
       date +%s000
 -->
 <property name='p2.atomic.composite.loading' value='false'/>
-<property name='p2.timestamp' value='1462953649000'/>
+<property name='p2.timestamp' value='1499433262000'/>
 </properties>
 <children size='17'>
 
@@ -21,8 +21,9 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.ox
 
   <child location='http://download.jboss.org/jbosstools/updates/requirements/xulrunner-1.9.2/'/>
   <child location='http://download.jboss.org/jbosstools/updates/stable/luna/core/portlet/'/>
+  <child location='http://download.jboss.org/jbosstools/neon/stable/updates/core/freemarker/'/>
 
-<!-- ## CHANGED SINCE 4.3.0.Final ## -->
+<!-- ## CHANGED SINCE 4.4.4.Final ## -->
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-aerogear_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-arquillian_4.5.oxygen/latest/all/repo/'/>
@@ -31,12 +32,11 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.ox
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-central_4.5.oxygen/latest/all/repo/'/>
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-forge_4.5.oxygen/latest/all/repo/'/>
-  <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-freemarker_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-hibernate_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-javaee_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-jst_4.5.oxygen/latest/all/repo/'/>
-
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-livereload_4.5.oxygen/latest/all/repo/'/>
+
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-openshift_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-server_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-vpe_4.5.oxygen/latest/all/repo/'/>

--- a/jbosstools/oxygen/snapshots/builds/_composite_/core/4.5.oxygen/compositeContent.xml
+++ b/jbosstools/oxygen/snapshots/builds/_composite_/core/4.5.oxygen/compositeContent.xml
@@ -8,7 +8,7 @@
       date +%s000
 -->
 <property name='p2.atomic.composite.loading' value='false'/>
-<property name='p2.timestamp' value='1462953649000'/>
+<property name='p2.timestamp' value='1499433262000'/>
 </properties>
 <children size='17'>
 
@@ -21,8 +21,9 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.ox
 
   <child location='http://download.jboss.org/jbosstools/updates/requirements/xulrunner-1.9.2/'/>
   <child location='http://download.jboss.org/jbosstools/updates/stable/luna/core/portlet/'/>
+  <child location='http://download.jboss.org/jbosstools/neon/stable/updates/core/freemarker/'/>
 
-<!-- ## CHANGED SINCE 4.3.0.Final ## -->
+<!-- ## CHANGED SINCE 4.4.4.Final ## -->
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-aerogear_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-arquillian_4.5.oxygen/latest/all/repo/'/>
@@ -31,12 +32,11 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.ox
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-central_4.5.oxygen/latest/all/repo/'/>
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-forge_4.5.oxygen/latest/all/repo/'/>
-  <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-freemarker_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-hibernate_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-javaee_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-jst_4.5.oxygen/latest/all/repo/'/>
-
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-livereload_4.5.oxygen/latest/all/repo/'/>
+
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-openshift_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-server_4.5.oxygen/latest/all/repo/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-vpe_4.5.oxygen/latest/all/repo/'/>

--- a/jbosstools/oxygen/snapshots/builds/_composite_/core/master/compositeArtifacts.xml
+++ b/jbosstools/oxygen/snapshots/builds/_composite_/core/master/compositeArtifacts.xml
@@ -8,21 +8,22 @@
       date +%s000
 -->
 <property name='p2.atomic.composite.loading' value='false'/>
-<property name='p2.timestamp' value='1462953649000'/>
+<property name='p2.timestamp' value='1499433262000'/>
 </properties>
 <children size='17'>
 
 <!-- TODO: when adding new builds here, remember to add them to these jobs too:
 https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_master/
-https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.4.neon/
+https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.oxygen/
 -->
 
 <!-- ## UNCHANGED SINCE previous releases ## -->
 
   <child location='http://download.jboss.org/jbosstools/updates/requirements/xulrunner-1.9.2/'/>
   <child location='http://download.jboss.org/jbosstools/updates/stable/luna/core/portlet/'/>
+  <child location='http://download.jboss.org/jbosstools/neon/stable/updates/core/freemarker/'/>
 
-<!-- ## CHANGED SINCE 4.3.0.Final ## -->
+<!-- ## CHANGED SINCE 4.4.4.Final ## -->
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-aerogear_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-arquillian_master/'/>
@@ -31,12 +32,11 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.4.ne
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-central_master/'/>
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-forge_master/'/>
-  <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-freemarker_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-hibernate_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-javaee_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-jst_master/'/>
-
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-livereload_master/'/>
+
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-openshift_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-server_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-vpe_master/'/>

--- a/jbosstools/oxygen/snapshots/builds/_composite_/core/master/compositeContent.xml
+++ b/jbosstools/oxygen/snapshots/builds/_composite_/core/master/compositeContent.xml
@@ -8,21 +8,22 @@
       date +%s000
 -->
 <property name='p2.atomic.composite.loading' value='false'/>
-<property name='p2.timestamp' value='1462953649000'/>
+<property name='p2.timestamp' value='1499433262000'/>
 </properties>
 <children size='17'>
 
 <!-- TODO: when adding new builds here, remember to add them to these jobs too:
 https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_master/
-https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.4.neon/
+https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.5.oxygen/
 -->
 
 <!-- ## UNCHANGED SINCE previous releases ## -->
 
   <child location='http://download.jboss.org/jbosstools/updates/requirements/xulrunner-1.9.2/'/>
   <child location='http://download.jboss.org/jbosstools/updates/stable/luna/core/portlet/'/>
+  <child location='http://download.jboss.org/jbosstools/neon/stable/updates/core/freemarker/'/>
 
-<!-- ## CHANGED SINCE 4.3.0.Final ## -->
+<!-- ## CHANGED SINCE 4.4.4.Final ## -->
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-aerogear_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-arquillian_master/'/>
@@ -31,12 +32,11 @@ https://jenkins.mw.lab.eng.bos.redhat.com/hudson/job/jbosstools-buildflow_4.4.ne
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-central_master/'/>
 
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-forge_master/'/>
-  <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-freemarker_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-hibernate_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-javaee_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-jst_master/'/>
-
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-livereload_master/'/>
+
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-openshift_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-server_master/'/>
   <child location='http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-vpe_master/'/>


### PR DESCRIPTION
use http://download.jboss.org/jbosstools/neon/stable/updates/core/freemarker/ instead of 'http://download.jboss.org/jbosstools/oxygen/snapshots/builds/jbosstools-freemarker*' (JBIDE-24484)

Signed-off-by: nickboldt <nboldt@redhat.com>