### PR TITLE
Fix central software earlyaccess page

### DIFF
--- a/jbosstools/configuration/ide-config.properties
+++ b/jbosstools/configuration/ide-config.properties
@@ -20,17 +20,17 @@ jboss.fuse.extras.site.url|jbosstools|4.27.0.AM1=https://download.jboss.org/jbos
 
 ### latest milestone
 # JBT 4.26.0.AM1
-jboss.discovery.directory.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/jbosstools-directory.xml
-jboss.discovery.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.central/4.26.0.AM1
-jboss.discovery.earlyaccess.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/
-jboss.discovery.earlyaccess.list.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/jbosstools-earlyaccess.properties
-jboss.central.webpage.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/static/redhat-central/jbosstools-central-webpage-2.0.0-20191001.1470.zip
-jboss.fuse.extras.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/fuse-extras/4.26.0.AM1/
+#jboss.discovery.directory.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/jbosstools-directory.xml
+#jboss.discovery.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.central/4.26.0.AM1
+#jboss.discovery.earlyaccess.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/
+#jboss.discovery.earlyaccess.list.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/discovery.earlyaccess/4.26.0.AM1/jbosstools-earlyaccess.properties
+#jboss.central.webpage.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/static/redhat-central/jbosstools-central-webpage-2.0.0-20191001.1470.zip
+#jboss.fuse.extras.site.url|jbosstools|4.26.0.AM1=https://download.jboss.org/jbosstools/photon/development/updates/fuse-extras/4.26.0.AM1/
 
 
 ### latest stable
 # JBT 4.26.0.Final
-jboss.discovery.directory.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.central/4.26.0.Final/jbosstools-directory.xml
+jboss.discovery.directory.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/jbosstools-directory.xml
 jboss.discovery.site.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.central/4.26.0.Final
 jboss.discovery.earlyaccess.site.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/
 jboss.discovery.earlyaccess.list.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/jbosstools-earlyaccess.properties
@@ -58,7 +58,7 @@ jboss.fuse.extras.site.url|jbosstools|4.26.0=https://download.jboss.org/jbosstoo
 
 ##Discovery
 # =========
-# JBT 4.25.0.Final / eclipse 4.25 (2022-06)
+# JBT 4.25.0.Final / eclipse 4.25 (2022-09)
 jboss.discovery.directory.url|jbosstools|4.25.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.25.0.Final/jbosstools-directory.xml
 jboss.discovery.site.url|jbosstools|4.25.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.central/4.25.0.Final
 jboss.discovery.earlyaccess.site.url|jbosstools|4.25.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.25.0.Final/

--- a/jbosstools/configuration/src/main/ide-config.current-stable-fragment.properties
+++ b/jbosstools/configuration/src/main/ide-config.current-stable-fragment.properties
@@ -1,6 +1,6 @@
 ### latest stable
 # JBT 4.26.0.Final
-jboss.discovery.directory.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.central/4.26.0.Final/jbosstools-directory.xml
+jboss.discovery.directory.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/jbosstools-directory.xml
 jboss.discovery.site.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.central/4.26.0.Final
 jboss.discovery.earlyaccess.site.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/
 jboss.discovery.earlyaccess.list.url|jbosstools|4.26.0=https://download.jboss.org/jbosstools/photon/stable/updates/discovery.earlyaccess/4.26.0.Final/jbosstools-earlyaccess.properties

--- a/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeArtifacts.xml
+++ b/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeArtifacts.xml
@@ -1,8 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?><?compositeArtifactRepository version='1.0.0'?>
-<repository name='photon/staging/updates/discovery.earlyaccess' type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository' version='1.0.0'>
-<properties size='2'><property name='p2.timestamp' value='1671439914000'/><property name='p2.compressed' value='true'/></properties>
-<children size='1'>
-<child location='4.26.0.AM1/'/>
-</children>
-</repository>
-

--- a/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeArtifacts.xml
+++ b/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeArtifacts.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?compositeArtifactRepository version='1.0.0'?>
+<repository name='JBoss Tools - Core + Central Update Site' type='org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository' version='1.0.0'>
+  <properties size='2'>
+    <property name='p2.timestamp' value='1671439914001'/>
+    <property name='p2.compressed' value='true'/>
+  </properties>
+  <children size='4'>
+  	<child location='https://download.jboss.org/jbosstools/targetplatforms/jbosstoolstarget/4.26.0.Final-SNAPSHOT/REPO/'/>
+  	<child location='https://download.jboss.org/jbosstools/static/photon/stable/updates/core/4.26.0.Final/'/>
+  	<child location='https://download.jboss.org/jbosstools/static/photon/stable/updates/central/4.26.0.Final/'/>
+  	<child location='https://download.jboss.org/jbosstools/targetplatforms/jbtcentraltarget/4.26.0.Final-SNAPSHOT/REPO/'/>
+  </children>
+</repository>

--- a/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeContent.xml
+++ b/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeContent.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<?compositeMetadataRepository version='1.0.0'?>
+<repository name='JBoss Tools - Core + Central Update Site' type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository' version='1.0.0'>
+  <properties size='2'>
+    <property name='p2.timestamp' value='1671439914001'/>
+    <property name='p2.compressed' value='true'/>
+  </properties>
+  <children size='4'>
+  	<child location='https://download.jboss.org/jbosstools/targetplatforms/jbosstoolstarget/4.26.0.Final-SNAPSHOT/REPO/'/>
+  	<child location='https://download.jboss.org/jbosstools/static/photon/stable/updates/core/4.26.0.Final/'/>
+  	<child location='https://download.jboss.org/jbosstools/static/photon/stable/updates/central/4.26.0.Final/'/>
+  	<child location='https://download.jboss.org/jbosstools/targetplatforms/jbtcentraltarget/4.26.0.Final-SNAPSHOT/REPO/'/>
+  </children>
+</repository>

--- a/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeContent.xml
+++ b/jbosstools/photon/stable/updates/discovery.earlyaccess/compositeContent.xml
@@ -1,8 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?><?compositeArtifactRepository version='1.0.0'?>
-<repository name='photon/staging/updates/discovery.earlyaccess' type='org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository' version='1.0.0'>
-<properties size='2'><property name='p2.timestamp' value='1671439914000'/><property name='p2.compressed' value='true'/></properties>
-<children size='1'>
-<child location='4.26.0.AM1/'/>
-</children>
-</repository>
-


### PR DESCRIPTION
reverting config URL to earlyaccess to brng back fabric8 dependency analytics